### PR TITLE
Test dynamic instant navigation

### DIFF
--- a/app/page.js
+++ b/app/page.js
@@ -126,7 +126,11 @@ export default function Home() {
           </p>
           <p className="text-neutral-300">
             Read my latest articles in my{' '}
-            <Link href="/blog" className="underline text-white hover:text-neutral-400">
+            <Link
+              href="/blog"
+              prefetch={true}
+              className="underline text-white hover:text-neutral-400"
+            >
               blog
             </Link>
             .

--- a/components/layout.js
+++ b/components/layout.js
@@ -14,7 +14,11 @@ const LayoutComponent = ({ children }) => {
       <div className="flex justify-center">{children}</div>
       <footer>
         <div className="mt-16 flex flex-wrap items-center justify-center gap-x-4 gap-y-3 text-center text-neutral-300">
-          <Link href="/blog" className="underline hover:text-neutral-400 transition-colors">
+          <Link
+            href="/blog"
+            prefetch={true}
+            className="underline hover:text-neutral-400 transition-colors"
+          >
             Blog
           </Link>
           <a href="https://foroneperson.com" className="underline hover:text-neutral-400 transition-colors">

--- a/docs/next-16-3-migration.md
+++ b/docs/next-16-3-migration.md
@@ -12,6 +12,8 @@ changes and checks here are intended to inform later repository migrations.
   `cacheLife`.
 - Added a static blog shell with a Suspense boundary around CMS data so the
   route can navigate instantly while posts stream in.
+- Opted the main blog links into `prefetch={true}` so Partial Prefetching sends
+  the page shell before navigation, including when CMS data is dynamic.
 - Removed `generateStaticParams` from the dynamic CMS-backed post route. Cache
   Components requires it to return at least one path during every build, which
   is not reliable when build-time CMS credentials are intentionally absent.
@@ -36,19 +38,22 @@ changes and checks here are intended to inform later repository migrations.
 3. Short-lived cached data should sit behind the smallest useful Suspense
    boundary. Keep headings and navigation outside it to produce a useful,
    testable instant shell.
-4. A cached helper must have deterministic arguments and must not capture
+4. A Suspense shell is not automatically proof of an instant navigation. Test
+   with production-like dynamic data and opt important entry links into
+   `prefetch={true}` when the default prefetch does not include the page shell.
+5. A cached helper must have deterministic arguments and must not capture
    mutable module state. Normalize complex arguments before crossing the cache
    boundary.
-5. Cache Components does not support the Edge runtime. Inventory `runtime =
+6. Cache Components does not support the Edge runtime. Inventory `runtime =
    'edge'` before enabling it and verify that each route can move to Node.js.
-6. `generateStaticParams()` cannot return an empty array with Cache Components.
+7. `generateStaticParams()` cannot return an empty array with Cache Components.
    Remove it for fully dynamic routes or guarantee a real build-time path.
-7. Test the standalone production server, not only `next dev`, because partial
+8. Test the standalone production server, not only `next dev`, because partial
    prefetching and the `instant()` helper exercise production behavior.
-8. Audit production dependencies after the upgrade. This migration also moved
+9. Audit production dependencies after the upgrade. This migration also moved
    `sharp` to 0.35 because the older direct dependency had a high-severity
    advisory.
-9. Exercise dynamic image routes concurrently. For Node.js `ImageResponse`,
+10. Exercise dynamic image routes concurrently. For Node.js `ImageResponse`,
    prefer traced local TTF/OTF assets over remote WOFF downloads.
 
 ## Verification command

--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
     "build": "next build",
     "start": "next start",
     "lint": "eslint .",
-    "test": "npm run lint && npm run build && npm run test:e2e",
-    "test:e2e": "node scripts/prepare-standalone.mjs && playwright test"
+    "test": "npm run lint && npm run build:test && npm run test:e2e",
+    "test:e2e": "node scripts/prepare-standalone.mjs && playwright test",
+    "build:test": "LEMENO_APP_URL=http://127.0.0.1:9 MONGODB_ATLAS_API_KEY=playwright-test next build"
   },
   "engines": {
     "node": ">=20.9.0"

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -19,6 +19,8 @@ module.exports = defineConfig({
       ...process.env,
       HOSTNAME: '127.0.0.1',
       PORT: String(PORT),
+      LEMENO_APP_URL: 'http://127.0.0.1:9',
+      MONGODB_ATLAS_API_KEY: 'playwright-test',
     },
     url: `http://127.0.0.1:${PORT}`,
     reuseExistingServer: false,


### PR DESCRIPTION
## Summary

- opt the site's main Blog links into full partial prefetching
- make the browser test build use a production-like dynamic CMS boundary instead of silently prerendering an empty static blog
- document that a Suspense shell alone does not prove an instant navigation

## Why

Production verification of PR #30 found that the Blog heading was not present inside Next.js 16.3's `instant()` navigation lock. The original local test had passed for the wrong reason: missing local CMS credentials made `/blog` fully static. Building the test fixture with a configured-but-unavailable CMS correctly produces a partial prerender and exposed the missing `prefetch={true}` on the entry links.

## Validation

- `npm test`: ESLint, a production-like partial-prerender build (`/blog` is `◐`), and 6/6 desktop/mobile Playwright checks
- the `instant()` check now exercises the same dynamic boundary shape as production
