### PR TITLE
Keep RSS data runtime-backed

### DIFF
--- a/app/rss.xml/route.js
+++ b/app/rss.xml/route.js
@@ -1,6 +1,7 @@
 import { getBlogPosts, getOriginal } from '@/lib/mongodb';
 import { buildRssFeed } from '@/lib/rss';
 import { cacheLife } from 'next/cache';
+import { connection } from 'next/server';
 
 const BASE_URL = 'https://filipenevola.com';
 const FEED_DESCRIPTION =
@@ -21,6 +22,7 @@ async function getFeed() {
 }
 
 export async function GET() {
+  await connection();
   const feed = await getFeed();
 
   return new Response(feed, {

--- a/docs/next-16-3-migration.md
+++ b/docs/next-16-3-migration.md
@@ -23,7 +23,8 @@ changes and checks here are intended to inform later repository migrations.
 - Removed `usePathname()` from the shared layout because identical markup was
   rendered for every page; this keeps the layout prerenderable.
 - Migrated the RSS route from `dynamic`/`revalidate` segment exports to an
-  explicit cached helper.
+  explicit cached helper, with `connection()` keeping runtime-only deployment
+  credentials out of prerendering.
 - Added ESLint flat config because `next build` does not run lint checks.
 - Added desktop and mobile Playwright coverage, including the 16.3 `instant()`
   navigation helper.
@@ -55,6 +56,9 @@ changes and checks here are intended to inform later repository migrations.
    advisory.
 10. Exercise dynamic image routes concurrently. For Node.js `ImageResponse`,
    prefer traced local TTF/OTF assets over remote WOFF downloads.
+11. A cached Route Handler can still be prerendered with empty build-time data.
+    Use `connection()` when its data or credentials only exist at runtime, and
+    make the test fixture assert meaningful records rather than only a 200.
 
 ## Verification command
 

--- a/playwright.config.js
+++ b/playwright.config.js
@@ -13,19 +13,27 @@ module.exports = defineConfig({
     screenshot: 'only-on-failure',
     trace: 'retain-on-failure',
   },
-  webServer: {
-    command: 'node .next/standalone/server.js',
-    env: {
-      ...process.env,
-      HOSTNAME: '127.0.0.1',
-      PORT: String(PORT),
-      LEMENO_APP_URL: 'http://127.0.0.1:9',
-      MONGODB_ATLAS_API_KEY: 'playwright-test',
+  webServer: [
+    {
+      command: 'node scripts/mock-cms.mjs',
+      port: 4199,
+      reuseExistingServer: false,
+      timeout: 30_000,
     },
-    url: `http://127.0.0.1:${PORT}`,
-    reuseExistingServer: false,
-    timeout: 30_000,
-  },
+    {
+      command: 'node .next/standalone/server.js',
+      env: {
+        ...process.env,
+        HOSTNAME: '127.0.0.1',
+        PORT: String(PORT),
+        LEMENO_APP_URL: 'http://127.0.0.1:4199',
+        MONGODB_ATLAS_API_KEY: 'playwright-test',
+      },
+      url: `http://127.0.0.1:${PORT}`,
+      reuseExistingServer: false,
+      timeout: 30_000,
+    },
+  ],
   projects: [
     {
       name: 'desktop-chromium',

--- a/scripts/mock-cms.mjs
+++ b/scripts/mock-cms.mjs
@@ -1,0 +1,50 @@
+import { createServer } from 'node:http';
+
+const PORT = 4199;
+const original = {
+  _id: 'original-1',
+  slug: 'filipe-nevola',
+  name: 'Filipe Névola Blog',
+  description: 'Test blog content',
+  language: 'en-US',
+};
+const post = {
+  _id: 'post-1',
+  originalId: original._id,
+  slug: 'migration-test-post',
+  subject: 'Migration Test Post',
+  preHeader: 'Content supplied by the local CMS fixture.',
+  content:
+    '<p>This deterministic test article verifies that dynamic CMS content streams into the blog and remains present in the RSS feed after a production build.</p>',
+  publishedAt: '2026-08-03T12:00:00.000Z',
+};
+
+const server = createServer(async (request, response) => {
+  if (request.method !== 'POST' || request.url !== '/api/mongodb') {
+    response.writeHead(404).end();
+    return;
+  }
+
+  let body = '';
+  for await (const chunk of request) body += chunk;
+  const query = JSON.parse(body);
+  let documents = [];
+
+  if (query.collection === 'originals') {
+    documents = [original];
+  } else if (
+    query.collection === 'originalPosts' &&
+    (!query.filter?.slug || query.filter.slug === post.slug)
+  ) {
+    documents = [post];
+  }
+
+  response.writeHead(200, { 'Content-Type': 'application/json' });
+  response.end(JSON.stringify({ documents }));
+});
+
+server.listen(PORT, '127.0.0.1', () => {
+  console.log(`Mock CMS listening on http://127.0.0.1:${PORT}`);
+});
+
+process.on('SIGTERM', () => server.close());

--- a/tests/e2e/site.spec.js
+++ b/tests/e2e/site.spec.js
@@ -30,11 +30,24 @@ test('keeps the blog shell instant during client navigation', async ({ page }) =
   });
 });
 
+test('streams a CMS post into the blog and opens it', async ({ page }) => {
+  await page.goto('/blog');
+
+  await page.getByRole('link', { name: 'Migration Test Post' }).click();
+  await expect(
+    page.getByRole('heading', { name: 'Migration Test Post' })
+  ).toBeVisible();
+  await expect(page.getByText('deterministic test article')).toBeVisible();
+});
+
 test('serves RSS and Open Graph image endpoints', async ({ request }) => {
   const rss = await request.get('/rss.xml');
   expect(rss.ok()).toBeTruthy();
   expect(rss.headers()['content-type']).toContain('application/rss+xml');
-  expect(await rss.text()).toContain('<rss version="2.0"');
+  const rssText = await rss.text();
+  expect(rssText).toContain('<rss version="2.0"');
+  expect(rssText).toContain('<item>');
+  expect(rssText).toContain('Migration Test Post');
 
   const og = await request.get('/api/og?title=Migration%20test');
   expect(og.ok()).toBeTruthy();


### PR DESCRIPTION
## Summary

- force the cached RSS handler to execute at request time with `connection()`
- add a deterministic local CMS fixture for browser and route tests
- require the RSS test to contain a real item and verify the streamed post page on desktop and mobile
- document the runtime-only credential/prerendering lesson

## Root cause

Next.js 16.3 prerendered the cached RSS route during the deployment build. Quave ONE injects the CMS credentials at runtime, so the build generated and cached an empty feed. The previous test only checked the response type and RSS wrapper, allowing zero items to pass.

## Validation

- `npm test`: ESLint, production-like build showing `/rss.xml` as dynamic (`ƒ`), and 8/8 desktop/mobile Playwright checks
- CMS fixture proves blog streaming, post rendering, and a non-empty RSS feed
- `npm ci` audit: 0 vulnerabilities
