### PR TITLE
Restore runtime-backed blog posts

### DIFF
--- a/app/rss.xml/route.js
+++ b/app/rss.xml/route.js
@@ -1,6 +1,5 @@
 import { getBlogPosts, getOriginal } from '@/lib/mongodb';
 import { buildRssFeed } from '@/lib/rss';
-import { cacheLife } from 'next/cache';
 import { connection } from 'next/server';
 
 const BASE_URL = 'https://filipenevola.com';
@@ -8,9 +7,6 @@ const FEED_DESCRIPTION =
   'Thoughts on software development, entrepreneurship, and building products. By Filipe Névola.';
 
 async function getFeed() {
-  'use cache';
-  cacheLife({ stale: 600, revalidate: 600, expire: 86400 });
-
   const [posts, original] = await Promise.all([getBlogPosts(), getOriginal()]);
   return buildRssFeed({
     baseUrl: BASE_URL,

--- a/docs/next-16-3-migration.md
+++ b/docs/next-16-3-migration.md
@@ -32,6 +32,11 @@ changes and checks here are intended to inform later repository migrations.
 
 ## Important lessons for the next repositories
 
+- Runtime-only CMS credentials must be read after `connection()`. Do not put
+  these reads behind a build-persisted `use cache` boundary: an empty build-time
+  result can otherwise become the PPR response. RSS uses HTTP `Cache-Control`
+  for edge caching instead.
+
 1. Upgrade dependencies and get a clean baseline build before enabling the
    Instant Navigation flags.
 2. `cacheComponents: true` rejects route segment exports such as `dynamic` and

--- a/lib/mongodb.js
+++ b/lib/mongodb.js
@@ -1,12 +1,17 @@
-import { cacheLife } from 'next/cache';
+import { connection } from 'next/server';
 
-const LEMENO_APP_URL = process.env.LEMENO_APP_URL;
-const MONGODB_ATLAS_API_KEY = process.env.MONGODB_ATLAS_API_KEY;
 const ORIGINAL_SLUG = 'filipe-nevola';
 let didWarnMissingMongoConfig = false;
 
 async function mongoDBFind(options) {
-  if (!LEMENO_APP_URL || !MONGODB_ATLAS_API_KEY) {
+  // CMS credentials exist only in the running container. Crossing the request
+  // boundary prevents a missing build-time credential from becoming cached PPR
+  // content.
+  await connection();
+  const lemenoAppUrl = process.env.LEMENO_APP_URL;
+  const mongodbAtlasApiKey = process.env.MONGODB_ATLAS_API_KEY;
+
+  if (!lemenoAppUrl || !mongodbAtlasApiKey) {
     if (!didWarnMissingMongoConfig) {
       didWarnMissingMongoConfig = true;
       console.warn(
@@ -16,15 +21,7 @@ async function mongoDBFind(options) {
     return [];
   }
 
-  return mongoDBFindCached(JSON.stringify(options));
-}
-
-async function mongoDBFindCached(serializedOptions) {
-  'use cache';
-  cacheLife({ stale: 30, revalidate: 10, expire: 60 });
-
-  const url = `${LEMENO_APP_URL}/api/mongodb`;
-  const options = JSON.parse(serializedOptions);
+  const url = `${lemenoAppUrl}/api/mongodb`;
 
   try {
     const response = await fetch(url, {
@@ -32,7 +29,7 @@ async function mongoDBFindCached(serializedOptions) {
       headers: {
         'Content-Type': 'application/json',
         'Access-Control-Request-Headers': '*',
-        'api-key': MONGODB_ATLAS_API_KEY,
+        'api-key': mongodbAtlasApiKey,
       },
       body: JSON.stringify({
         database: 'lemeno',


### PR DESCRIPTION
## Summary
- force CMS reads across the runtime request boundary before reading injected credentials
- remove build-persisted CMS caching that captured an empty post list
- retain RSS edge caching through its existing HTTP cache headers

## Verification
- `npm test` (lint, production build, 8 Playwright tests across desktop/mobile)
- build output keeps `/blog` and `/blog/[slug]` as Partial Prerender routes and `/rss.xml` dynamic
- `npm audit`: 0 vulnerabilities
